### PR TITLE
Fix ips endpoint

### DIFF
--- a/lib/routes/ips.js
+++ b/lib/routes/ips.js
@@ -8,7 +8,7 @@ module.exports = {
   },
 
   all: function allIPs (req, res, next) {
-    res.body = req.forwarded.ips
+    res.body = req.ips
 
     next()
   }

--- a/test/http/index.js
+++ b/test/http/index.js
@@ -77,7 +77,7 @@ describe('HTTP', function () {
     })
 
     req.end(function (res) {
-      res.body.should.be.an.Array
+      res.body.should.be.an.Array()
       res.body.should.containDeep(['10.10.10.1', '10.10.10.2', '10.10.10.3'])
 
       done()

--- a/test/routes/ips.js
+++ b/test/routes/ips.js
@@ -25,16 +25,14 @@ describe('/ips', function () {
   it('should response with all address', function (done) {
     var res = {}
     var req = {
-      forwarded: {
-        ips: [
-          '0.0.0.0',
-          '1.1.1.1'
-        ]
-      }
+      ips: [
+        '0.0.0.0',
+        '1.1.1.1'
+      ]
     }
 
     ips.all(req, res, function () {
-      res.body.should.equal(req.forwarded.ips)
+      res.body.should.equal(req.ips)
 
       done()
     })


### PR DESCRIPTION
## Fix ips endpoint

I did a test proxying a call to mockbin with kong and it's not returning the Kong IP as body.  

So I've checked the Express docs then modified the `/ips` route to return `req.ips` instead of `req. forwarded.ips` 

