### PR TITLE
Update docker node version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+test
+docs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:0.10-onbuild
+FROM node:0.12-onbuild
 
-RUN npm config set mockbin:redis redis://redis:6379
+ENV MOCKBIN_PORT=8080
+ENV MOCKBIN_QUIET=false
+ENV MOCKBIN_REDIS=redis://redis:6379
+
 EXPOSE 8080


### PR DESCRIPTION
## Update docker node version

with the version 0.10-onbuild I'm getting an error after create a new bin.

```node
starting server on port: 8080
GET / 304 373.428 ms - -
GET /bin/create 200 96.940 ms - -
POST /bin/create 500 8.030 ms - 792
ReferenceError: Promise is not defined
    at validator (/usr/src/app/node_modules/har-validator/lib/promise.js:42:14)
    at Object.response (/usr/src/app/node_modules/har-validator/lib/promise.js:110:10)
    at Object.module.exports (/usr/src/app/lib/routes/bins/create.js:46:12)
    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)
    at next (/usr/src/app/node_modules/express/lib/router/route.js:131:13)
    at IncomingMessage.<anonymous> (/usr/src/app/lib/middleware/body-parser.js:52:9)
    at IncomingMessage.emit (events.js:92:17)
    at _stream_readable.js:944:16
    at process._tickCallback (node.js:458:13)
```

This PR will fix that.
This also ignores `node_modules` during the docker build