### PR TITLE
Fix typo in JSON and JSONP samples

### DIFF
--- a/src/static/bin/create.js
+++ b/src/static/bin/create.js
@@ -31,7 +31,7 @@ var sample = {
     cookies: [],
     content: {
       mimeType: 'application/json',
-      text: '{\n    "foo": "Hello Word"\n}'
+      text: '{\n    "foo": "Hello World"\n}'
     }
   },
 
@@ -48,7 +48,7 @@ var sample = {
     cookies: [],
     content: {
       mimeType: 'application/javascript',
-      text: 'callback({\n    "foo": "Hello Word"\n})'
+      text: 'callback({\n    "foo": "Hello World"\n})'
     }
   },
 


### PR DESCRIPTION
Change "Hello Word" to "Hello World" in order to match the XML and Plain Text samples.