### PR TITLE
Fixed broken DOCKERFILE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:0.10-onbuild
+FROM node:14-alpine
 
 RUN npm config set mockbin:redis redis://redis:6379
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:10-alpine
 
 RUN npm config set mockbin:redis redis://redis:6379
 EXPOSE 8080


### PR DESCRIPTION
Tried running ` docker build -t mockbin . ` and was presented with an error and my build failed.


Later realized that the DOCKERFILE hasn't been updated in more than half a decade and the package.json dependencies did not support node:0.10, the following error was generated:

![Screen Shot 2020-10-06 at 9 34 22 PM](https://user-images.githubusercontent.com/4549937/95279139-ea216e80-081f-11eb-90e3-533d7ffa2170.png)

Then Tried the docker build with node 14 - alpine and the entire app works like a charm, an outdated DOCKERFILE might turn away potential users and contributors  hence this fix!