### PR TITLE
Upgrade Dockerfile to use node:16-alpine

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,12 @@
-FROM node:0.10-onbuild
+FROM node:16-alpine
 
-RUN npm config set mockbin:redis redis://redis:6379
+# Create app directory
+WORKDIR /mockbin
+
+COPY package*.json ./
+RUN npm ci --only=production
+COPY . .
+
+ENV MOCKBIN_REDIS "redis://redis:6379"
 EXPOSE 8080
+CMD ["npm", "start"]


### PR DESCRIPTION
The existing build failed due to node:0.10 being very old.

Error: "No compatible version found: cz-conventional-changelog@'>=3.1.0 <4.0.0'"

Switching from `node:0.10-onbuild` to `node:16-alpine` required updates to the
Dockerfile, adding steps to install dependencies and copy the source code in to
the image itself. These are steps that `onbuild` performed for us automatically

The Dockerfile was also updated to use `MOCKBIN_REDIS` rather than the
`npm config set` method of enabling Redis as the `npm config set` method no
longer seems to work

Related to https://github.com/Kong/mockbin/issues/99