### PR TITLE
fix: url.auth already replace with url.username and url.password in node 16.0

### DIFF
--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -13,7 +13,7 @@ module.exports = function bins (dsnStr) {
 
   // connect to redis
   this.client = redis.createClient(dsn.port, dsn.hostname, {
-    auth_pass: dsn.auth ? dsn.auth.split(':').pop() : false
+    auth_pass: dsn.password ? dsn.password : false
   })
 
   this.client.on('error', function (err) {


### PR DESCRIPTION
`url.auth` is a [ legacy api](https://nodejs.org/api/url.html#legacy-urlobject) in node 16.0, will lead password field in redis DSN not working.