### PR TITLE
Support pathing

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ Mockbin is used internally and maintained by [Kong](https://github.com/Kong), wh
 
 ## Installation
 
+### Requirements
+
+- [Redis](http://redis.io/)
+
+```shell
+brew install redis
+brew services start redis
+```
+
+Redis should be now running on localhost:6379
+Mockbin will start without redis but you wont be able to set or get response bins.
+
 ```shell
 git clone https://github.com/Kong/mockbin.git ./mockbin
 cd mockbin
@@ -36,19 +48,6 @@ npm install
 ```
 
 Note: nvm, n or volta can be used instead of fnm.
-
-### Requirements
-
-other than the dependencies listed in [package.json](package.json) The following are required:
-
-- [Redis](http://redis.io/)
-
-```shell
-brew install redis
-brew services start redis
-```
-
-Redis should be now running on localhost:6379
 
 ### Running with Node
 

--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,8 @@
 		"rules": {
 			"recommended": true,
 			"complexity": {
-				"noForEach": "off"
+				"noForEach": "off",
+				"useArrowFunction": "off"
 			}
 		}
 	}

--- a/docs/api/bins.md
+++ b/docs/api/bins.md
@@ -262,7 +262,7 @@ You can request this endpoint with *any* combination of the following:
 ###### Request
 
 > ```http
-> GET /bin/3c149e20-bc9c-4c68-8614-048e6023a108/view HTTP/1.1
+> GET /bin/view/3c149e20-bc9c-4c68-8614-048e6023a108 HTTP/1.1
 > Host: mockbin.org
 > Accept: application/json
 > ```

--- a/docs/api/bins.md
+++ b/docs/api/bins.md
@@ -285,14 +285,14 @@ You can request this endpoint with *any* combination of the following:
 
 #### Bin Access Log
 
-> ##### `GET /bin/:id/log`
+> ##### `GET /bin/log/:id`
 
 List all requests made to this Bin, using [HAR](http://www.softwareishard.com/blog/har-12-spec/) log format.
 
 ###### Request
 
 > ```http
-> GET /bin/3c149e20-bc9c-4c68-8614-048e6023a108/log HTTP/1.1
+> GET /bin/log/3c149e20-bc9c-4c68-8614-048e6023a108 HTTP/1.1
 > Host: mockbin.org
 > Accept: application/json
 > ```

--- a/docs/api/bins.md
+++ b/docs/api/bins.md
@@ -93,16 +93,16 @@ Responds with a `Location` header with the newly created **Bin**, e.g. `Location
 
 #### Update Bin
 
-> ##### `PUT /bin/:id`
+> ##### `PUT /bin/:id/a/b/c`
 
-Updates a new **Bin** with a mock HTTP response as described by a [HAR Response Object](http://www.softwareishard.com/blog/har-12-spec/#response) body.
+Creates or updates a **Bin** with a mock HTTP response as described by a [HAR Response Object](http://www.softwareishard.com/blog/har-12-spec/#response) body. /a/b/c represeent any following paths than will be combined with the id for response matching.
 
-Responds with a `Location` header with the updated **Bin**, e.g. `Location: /bin/3c149e20-bc9c-4c68-8614-048e6023a108` *(the Bin ID is also repeated in the body)*
+Responds with a `Location` header with the updated **Bin**, e.g. `Location: /bin/3c149e20-bc9c-4c68-8614-048e6023a108/a/b/c` *(the Bin ID is also repeated in the body)*
 
 ###### Request
 
 > ```http
-> PUT /bin/3c149e20-bc9c-4c68-8614-048e6023a108 HTTP/1.1
+> PUT /bin/3c149e20-bc9c-4c68-8614-048e6023a108/a/b/c HTTP/1.1
 > Host: mockbin.org
 > Content-Type: application/json
 > Accept: application/json
@@ -162,7 +162,7 @@ Responds with a `Location` header with the updated **Bin**, e.g. `Location: /bin
 
 > ```http
 > HTTP/1.1 200 OK
-> Location: /bin/3c149e20-bc9c-4c68-8614-048e6023a108
+> Location: /bin/3c149e20-bc9c-4c68-8614-048e6023a108/a/b/c
 > Content-Type: application/json; charset=utf-8
 > Content-Length: 38
 >
@@ -252,11 +252,12 @@ The [HAR Response Object](http://www.softwareishard.com/blog/har-12-spec/#respon
 Each call to this endpoint will be [logged](#bin-log) *(max of 100 requests)*.
 
 You can request this endpoint with *any* combination of the following:
-  - HTTP methods *(e.g. `POST`, `XXPUT`)*
-  - HTTP headers *(e.g. `X-My-Header-Name: Value`)*
-  - body content *(max of 100mb)*
-  - query string *(e.g. `?foo=bar`)*
-  - path arguments *(e.g. `/bin/3c149e20-bc9c-4c68-8614-048e6023a108/any/extra/path/`)*
+
+- HTTP methods *(e.g. `POST`, `XXPUT`)*
+- HTTP headers *(e.g. `X-My-Header-Name: Value`)*
+- body content *(max of 100mb)*
+- query string *(e.g. `?foo=bar`)*
+- path arguments *(e.g. `/bin/3c149e20-bc9c-4c68-8614-048e6023a108/any/extra/path/`)*
 
 ###### Request
 

--- a/docs/api/bins.md
+++ b/docs/api/bins.md
@@ -173,14 +173,14 @@ Responds with a `Location` header with the updated **Bin**, e.g. `Location: /bin
 
 #### Inspect Bin
 
-> ##### `GET /bin/:id/view`
+> ##### `GET /bin/view/:id`
 
 Respondes with the [HAR Response Object](http://www.softwareishard.com/blog/har-12-spec/#response) sent at time of [creation](#create-bin).
 
 ###### Request
 
 > ```http
-> GET /bin/3c149e20-bc9c-4c68-8614-048e6023a108/view HTTP/1.1
+> GET /bin/view/3c149e20-bc9c-4c68-8614-048e6023a108 HTTP/1.1
 > Host: mockbin.org
 > Accept: application/json
 > ```
@@ -317,14 +317,14 @@ List all requests made to this Bin, using [HAR](http://www.softwareishard.com/bl
 
 #### Delete Bin
 
-> ##### `DELETE /bin/:id/delete`
+> ##### `DELETE /bin/delete/:id`
 
 Deletes the bin and all of its logs
 
 ###### Request
 
 > ```http
-> GET /bin/3c149e20-bc9c-4c68-8614-048e6023a108/view HTTP/1.1
+> GET /bin/view/3c149e20-bc9c-4c68-8614-048e6023a108 HTTP/1.1
 > ```
 
 ###### Response

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -44,7 +44,8 @@ module.exports = function bins(dsnStr) {
 		{ action: "post", path: "/create", route: routes.create.bind(this) },
 		{ action: "get", path: "/:uuid/view", route: routes.view.bind(this) },
 		{ action: "get", path: "/:uuid/sample", route: routes.sample.bind(this) },
-		{ action: "get", path: "/:uuid/log", route: routes.log.bind(this) },
+		// { action: "get", path: "/:uuid/log", route: routes.log.bind(this) },
+		{ action: "get", path: "/log/:uuid*", route: routes.log.bind(this) },
 		{
 			action: "delete",
 			path: "/:uuid/delete",

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -25,7 +25,7 @@ module.exports = function bins(dsnStr) {
 	}
 
 	this.client.on("error", (err) => {
-		debug("redis error:", err);
+		console.log("redis error:", err);
 	});
 
 	const router = express.Router();

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -50,7 +50,7 @@ module.exports = function bins(dsnStr) {
 			path: "/:uuid/delete",
 			route: routes.delete.bind(this),
 		},
-		{ action: "put", path: "/:uuid", route: routes.update.bind(this) },
+		{ action: "put", path: "/:uuid*", route: routes.update.bind(this) },
 		{ action: "all", path: "/:uuid*", route: routes.run.bind(this) },
 	];
 

--- a/lib/routes/bins.js
+++ b/lib/routes/bins.js
@@ -42,13 +42,12 @@ module.exports = function bins(dsnStr) {
 	const endpoints = [
 		{ action: "get", path: "/create", route: routes.form.bind(this) },
 		{ action: "post", path: "/create", route: routes.create.bind(this) },
-		{ action: "get", path: "/:uuid/view", route: routes.view.bind(this) },
-		{ action: "get", path: "/:uuid/sample", route: routes.sample.bind(this) },
-		// { action: "get", path: "/:uuid/log", route: routes.log.bind(this) },
+		{ action: "get", path: "/view/:uuid*", route: routes.view.bind(this) },
+		{ action: "get", path: "/sample/:uuid*", route: routes.sample.bind(this) },
 		{ action: "get", path: "/log/:uuid*", route: routes.log.bind(this) },
 		{
 			action: "delete",
-			path: "/:uuid/delete",
+			path: "/delete/:uuid*",
 			route: routes.delete.bind(this),
 		},
 		{ action: "put", path: "/:uuid*", route: routes.update.bind(this) },

--- a/lib/routes/bins/create.js
+++ b/lib/routes/bins/create.js
@@ -56,7 +56,7 @@ module.exports = async function (req, res, next) {
 
 		.catch((err) => {
 			res.body = {
-				errors: err.errors,
+				errors: err.message,
 			};
 		})
 

--- a/lib/routes/bins/log.js
+++ b/lib/routes/bins/log.js
@@ -3,8 +3,8 @@ const pkg = require("../../../package.json");
 
 module.exports = function (req, res, next) {
 	res.view = "bin/log";
-
-	this.client.lrange(`log:${req.params.uuid}`, 0, -1, (err, history) => {
+	const compoundId = req.params.uuid + req.params[0];
+	this.client.lrange(`log:${compoundId}`, 0, -1, (err, history) => {
 		if (err) {
 			debug(err);
 

--- a/lib/routes/bins/run.js
+++ b/lib/routes/bins/run.js
@@ -1,8 +1,10 @@
 const debug = require("debug")("mockbin");
 
 module.exports = function (req, res, next) {
+	// compoundId allows us to provide paths in the id to resolve to a specific bin
+	const compoundId = req.params.uuid + req.params[0];
 	this.client.get(
-		`bin:${req.params.uuid}`,
+		`bin:${compoundId}`,
 		function (err, value) {
 			if (err) {
 				debug(err);
@@ -15,10 +17,10 @@ module.exports = function (req, res, next) {
 
 				// log interaction & send the appropriate response based on HAR
 				this.client.rpush(
-					`log:${req.params.uuid}`,
+					`log:${compoundId}`,
 					JSON.stringify(req.har.log.entries[0]),
 				);
-				this.client.ltrim(`log:${req.params.uuid}`, 0, 100);
+				this.client.ltrim(`log:${compoundId}`, 0, 100);
 
 				// headers
 				har.headers.map((header) => {

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -18,7 +18,6 @@ module.exports = function (req, res, next) {
 		}
 	}
 	if (!mock) {
-		res.status(400);
 		res.body = {
 			errors: "Response HAR is required",
 		};
@@ -30,7 +29,6 @@ module.exports = function (req, res, next) {
 	const isPathSupported = isAlphanumericAndSlashes && !path.includes("//");
 
 	if (path && !isPathSupported) {
-		res.status(400);
 		res.body = {
 			errors: `Unsupported path ${path}`,
 		};

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -4,20 +4,11 @@ const validate = require("har-validator");
 module.exports = function (req, res, next) {
 	const id = req.params.uuid;
 	let mock = req.jsonBody;
-
-	// check for full HAR
-	if (req.jsonBody?.response) {
-		mock = req.jsonBody.response;
-	}
-
-	// exception for the web Form
-	// TODO eliminate this and rely on req.simple.postData.text
-	if (req.simple.postData.params?.response) {
-		try {
-			mock = JSON.parse(req.simple.postData.params.response);
-		} catch (e) {
-			debug(e);
-		}
+	if (!mock) {
+		res.body = {
+			errors: "Response HAR is required",
+		};
+		next();
 	}
 
 	// overritten by application/x-www-form-urlencoded or multipart/form-data

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -1,5 +1,4 @@
 const debug = require("debug")("mockbin");
-const util = require("util");
 const validate = require("har-validator");
 
 module.exports = function (req, res, next) {
@@ -49,7 +48,7 @@ module.exports = function (req, res, next) {
 				this.client.set(`bin:${compoundId}`, JSON.stringify(mock));
 
 				res.view = "redirect";
-				res.status(200).location(util.format("/bin/%s", id)).body = id;
+				res.status(200).location(`/bin/${compoundId}`).body = id;
 			}.bind(this),
 		)
 		.catch((err) => {

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -48,7 +48,7 @@ module.exports = function (req, res, next) {
 				const isPathSupported =
 					/^[a-zA-Z0-9\/]+$/i.test(path) && !path.includes("//");
 				if (!isPathSupported) {
-					throw new Error("Path is not supported");
+					throw new Error(`Unsupported path: ${path}`);
 				}
 				const compoundId = id + path;
 				this.client.set(`bin:${compoundId}`, JSON.stringify(mock));

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -44,7 +44,13 @@ module.exports = function (req, res, next) {
 		.response(mock)
 		.then(
 			function () {
-				const compoundId = id + req.params[0];
+				const path = req.params[0];
+				const isPathSupported =
+					/^[a-zA-Z0-9\/]+$/i.test(path) && !path.includes("//");
+				if (!isPathSupported) {
+					throw new Error("Path is not supported");
+				}
+				const compoundId = id + path;
 				this.client.set(`bin:${compoundId}`, JSON.stringify(mock));
 
 				res.view = "redirect";

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -1,15 +1,13 @@
 const debug = require("debug")("mockbin");
 const validate = require("har-validator");
+const path = require("path");
 
 module.exports = function (req, res, next) {
 	const id = req.params.uuid;
+	const path = req.params[0];
+	const compoundId = id + path;
+
 	let mock = req.jsonBody;
-	if (!mock) {
-		res.body = {
-			errors: "Response HAR is required",
-		};
-		next();
-	}
 
 	// overritten by application/x-www-form-urlencoded or multipart/form-data
 	if (req.simple.postData.text) {
@@ -18,6 +16,26 @@ module.exports = function (req, res, next) {
 		} catch (e) {
 			debug(e);
 		}
+	}
+	if (!mock) {
+		res.status(400);
+		res.body = {
+			errors: "Response HAR is required",
+		};
+		next();
+		return;
+	}
+
+	const isAlphanumericAndSlashes = /^[a-zA-Z0-9\/]+$/i.test(path);
+	const isPathSupported = isAlphanumericAndSlashes && !path.includes("//");
+
+	if (path && !isPathSupported) {
+		res.status(400);
+		res.body = {
+			errors: `Unsupported path ${path}`,
+		};
+		next();
+		return;
 	}
 
 	// provide optional values before validation
@@ -35,13 +53,6 @@ module.exports = function (req, res, next) {
 		.response(mock)
 		.then(
 			function () {
-				const path = req.params[0];
-				const isPathSupported =
-					/^[a-zA-Z0-9\/]+$/i.test(path) && !path.includes("//");
-				if (path && !isPathSupported) {
-					throw new Error(`Unsupported path: ${path}`);
-				}
-				const compoundId = id + path;
 				this.client.set(`bin:${compoundId}`, JSON.stringify(mock));
 
 				res.view = "redirect";

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -45,16 +45,16 @@ module.exports = function (req, res, next) {
 		.response(mock)
 		.then(
 			function () {
-				this.client.set(`bin:${id}`, JSON.stringify(mock));
+				const compoundId = id + req.params[0];
+				this.client.set(`bin:${compoundId}`, JSON.stringify(mock));
 
 				res.view = "redirect";
 				res.status(200).location(util.format("/bin/%s", id)).body = id;
 			}.bind(this),
 		)
-
 		.catch((err) => {
 			res.body = {
-				errors: err.errors,
+				errors: err.message,
 			};
 		})
 

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -47,7 +47,7 @@ module.exports = function (req, res, next) {
 				const path = req.params[0];
 				const isPathSupported =
 					/^[a-zA-Z0-9\/]+$/i.test(path) && !path.includes("//");
-				if (!isPathSupported) {
+				if (path && !isPathSupported) {
 					throw new Error(`Unsupported path: ${path}`);
 				}
 				const compoundId = id + path;

--- a/lib/routes/bins/update.js
+++ b/lib/routes/bins/update.js
@@ -25,17 +25,6 @@ module.exports = function (req, res, next) {
 		return;
 	}
 
-	const isAlphanumericAndSlashes = /^[a-zA-Z0-9\/]+$/i.test(path);
-	const isPathSupported = isAlphanumericAndSlashes && !path.includes("//");
-
-	if (path && !isPathSupported) {
-		res.body = {
-			errors: `Unsupported path ${path}`,
-		};
-		next();
-		return;
-	}
-
 	// provide optional values before validation
 	mock.redirectURL = "";
 	mock.bodySize = 0;

--- a/src/views/bin/log.pug
+++ b/src/views/bin/log.pug
@@ -9,12 +9,12 @@ mixin method (method)
 block content
   div(data-page="bin/log").container
     div.btn-group.pull-right.hidden-xs
-      a(href= '/bin/' + req.params.uuid + '/view').btn.btn-primary View Details
+      a(href= '/bin/view/' + req.params.uuid).btn.btn-primary View Details
 
     h3 Bin History: #[code= req.params.uuid]
 
     div.visible-xs
-      a(href= '/bin/' + req.params.uuid + '/view').btn.btn-block.btn-primary View Details
+      a(href= '/bin/view' + req.params.uuid).btn.btn-block.btn-primary View Details
 
     hr
 

--- a/src/views/bin/view.pug
+++ b/src/views/bin/view.pug
@@ -14,7 +14,7 @@ block content
 
         a(href= '#apiembed').btn.btn-block.btn-primary #[span.badge 1] &nbsp; Send Some Requests
         a(href= '/bin/' + req.params.uuid).btn.btn-block.btn-primary #[span.badge 2] &nbsp; Visit in Browser
-        a(href= '/bin/' + req.params.uuid + '/log').btn.btn-block.btn-primary #[span.badge 3] &nbsp; View History
+        a(href= '/bin/log/' + req.params.uuid).btn.btn-block.btn-primary #[span.badge 3] &nbsp; View History
 
     br
 

--- a/src/views/redirect.pug
+++ b/src/views/redirect.pug
@@ -1,7 +1,7 @@
 doctype html
 html
   head
-    meta(http-equiv='refresh', content=`0; url=${res.getHeaders().location}/view`)
+    meta(http-equiv='refresh', content=`0; url=${res.getHeaders().location.replace('/bin','/bin/view')}`)
 
   body
-    p Redirecting to #[a(href=res.getHeaders().location)= res.getHeaders().location + '/view']
+    p Redirecting to #[a(href=res.getHeaders().location)= res.getHeaders().location.replace('/bin','/bin/view')]


### PR DESCRIPTION
motivation: as a user i might like to mock an api surface with multiple endpoints and responses a varying paths.

problem: mockbin generates an id on bin creation that is used for the path so paths that follow the id are ignored or unmatched by express.

aim: the following could all return different responses
`bin/123-123-123-123/route-a`
`bin/123-123-123-123/route-b`
`bin/123-123-123-123/route-b/route-1`



approach
- include the path in the redis key
- avoids making redis values into arrays of responses per path
- use the url and a put method to indicate path to match

NOTE: you must first initialise a a mock response with a PUT request to a url you would like to mock with a HAR body of the response

to do
- [x] rotate log, view, sample endpoint paths to avoid conflict
  - alternatively since we only use log run and update, we could create a new route 
 
Questions:
- what should happen when and endpoint hasn't been initialised?

future work
- [ ] validation, bad input errors, 
  - do this later when we understand usage better
- [ ] sanitization: trailing slashes, query params, max key size, perf implications, 
  - do this later when we understand usage better
- [ ] support mocked methods besides GET, eg POST, PUT, DELETE
  - will mean using the request body to configure the path rather than the url
